### PR TITLE
PR #13 patch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44455,13 +44455,15 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(2186)
-const run = __nccwpck_require__(2475)
+const run = __nccwpck_require__(2475); // semicolon is intentional for standardjs
 
-try {
-  run()
-} catch (err) {
-  core.setFailed(err.message)
-}
+(async () => {
+  try {
+    await run()
+  } catch (err) {
+    core.setFailed(err.message)
+  }
+})()
 
 })();
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -44146,7 +44146,7 @@ const core = __nccwpck_require__(2186)
 const github = __nccwpck_require__(8396)
 const utils = __nccwpck_require__(1608)
 
-const run = async () => {
+module.exports = async () => {
   const octokit = github.getOctokit(core.getInput('github-token'))
 
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
@@ -44176,8 +44176,6 @@ const run = async () => {
   const incrementedVersion = semver.inc(latestTag.name, bump)
   utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
 }
-
-module.exports = { run }
 
 
 /***/ }),
@@ -44456,9 +44454,14 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const run = (__nccwpck_require__(2475).run)
+const core = __nccwpck_require__(2186)
+const run = __nccwpck_require__(2475)
 
-run()
+try {
+  run()
+} catch (err) {
+  core.setFailed(err.message)
+}
 
 })();
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
-const run = require('./run').run
+const core = require('@actions/core')
+const run = require('./run')
 
-run()
+try {
+  run()
+} catch (err) {
+  core.setFailed(err.message)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 const core = require('@actions/core')
-const run = require('./run')
+const run = require('./run'); // semicolon is intentional for standardjs
 
-try {
-  run()
-} catch (err) {
-  core.setFailed(err.message)
-}
+(async () => {
+  try {
+    await run()
+  } catch (err) {
+    core.setFailed(err.message)
+  }
+})()

--- a/src/run.js
+++ b/src/run.js
@@ -3,7 +3,7 @@ const core = require('@actions/core')
 const github = require('./github')
 const utils = require('./utils')
 
-const run = async () => {
+module.exports = async () => {
   const octokit = github.getOctokit(core.getInput('github-token'))
 
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
@@ -33,5 +33,3 @@ const run = async () => {
   const incrementedVersion = semver.inc(latestTag.name, bump)
   utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
 }
-
-module.exports = { run }

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -7,7 +7,7 @@ jest.spyOn(core, 'getInput')
 jest.spyOn(core, 'setFailed')
 jest.spyOn(core, 'setOutput')
 
-const run = require('./run').run
+const run = require('./run')
 
 describe('index', () => {
   beforeEach(() => {


### PR DESCRIPTION
This provides a possible patch to PR #13 which addresses the following:

- Remove duplicate file name and method `run.run()` by exporting a single method from the `run.js` file
- Wrap the `index.js` file in a try/catch to capture any unhandled exceptions gracefully without a full NodeJS trace dump.